### PR TITLE
Add onboarding flow

### DIFF
--- a/Companion/Extensions/Bundle+Icon.swift
+++ b/Companion/Extensions/Bundle+Icon.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SwiftUI
+
+#if canImport(UIKit)
+    import UIKit
+
+    extension Bundle {
+        public var icon: UIImage? {
+            if let icons = infoDictionary?["CFBundleIcons"] as? [String: Any],
+                let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
+                let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
+                let lastIcon = iconFiles.last
+            {
+                return UIImage(named: lastIcon)
+            }
+            return nil
+        }
+    }
+#elseif canImport(AppKit)
+    import AppKit
+
+    extension Bundle {
+        public var icon: NSImage? {
+            if let iconFileName = infoDictionary?["CFBundleIconFile"] as? String {
+                return NSImage(named: iconFileName)
+            }
+            return NSImage(named: "AppIcon")
+        }
+    }
+#endif
+
+// MARK: -
+
+struct AppIconImage: View {
+    let size: CGFloat
+    let cornerRadius: CGFloat
+
+    init(size: CGFloat = 80, cornerRadius: CGFloat = 16) {
+        self.size = size
+        self.cornerRadius = cornerRadius
+    }
+
+    var body: some View {
+        #if canImport(UIKit)
+        if let icon = Bundle.main.icon {
+            Image(uiImage: icon)
+                .resizable()
+                .scaledToFill()
+                .frame(width: size, height: size)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        } else {
+            fallbackIcon
+        }
+        #elseif canImport(AppKit)
+        if let icon = Bundle.main.icon {
+            Image(nsImage: icon)
+                .resizable()
+                .scaledToFill()
+                .frame(width: size, height: size)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        } else {
+            fallbackIcon
+        }
+        #endif
+    }
+
+    private var fallbackIcon: some View {
+        Image(systemName: "mcp.fill")
+            .font(.system(size: size * 0.6, weight: .light))
+            .foregroundStyle(.secondary)
+            .frame(width: size, height: size)
+            .background(.quaternary)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+}

--- a/Companion/Features/AppFeature.swift
+++ b/Companion/Features/AppFeature.swift
@@ -36,6 +36,7 @@ struct AppFeature {
         case loadingChanged(Bool)
         case errorOccurred(String?)
         case presentAddServer
+        case addExampleServer
         case addServerPresentation(PresentationAction<AddServerFeature.Action>)
         case presentEditServer(Server)
         case editServer(PresentationAction<EditServerFeature.Action>)
@@ -189,6 +190,18 @@ struct AppFeature {
             case .presentAddServer:
                 state.addServer = AddServerFeature.State()
                 return .none
+
+            case .addExampleServer:
+                let exampleServer = Server(
+                    name: "Everything",
+                    configuration: .init(stdio: "npx", arguments: ["-y", "@modelcontextprotocol/server-everything"])
+                )
+                print("AppFeature: Adding example server '\(exampleServer.name)'")
+                return .run { send in
+                    await serverClient.addServer(exampleServer)
+                    print("AppFeature: Example server added, now auto-connecting...")
+                    await send(.serverDetail(id: exampleServer.id, action: .connect))
+                }
 
             case .addServerPresentation(.presented(.addServer(let name, let transport))):
                 let newServer = Server(

--- a/Companion/Views/Onboarding/WelcomeView.swift
+++ b/Companion/Views/Onboarding/WelcomeView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct WelcomeView: View {
+    let onAddServer: () -> Void
+    let onAddExampleServer: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 32) {
+            // Heading
+            VStack(spacing: 16) {
+                AppIconImage(size: 80, cornerRadius: 16)
+                
+                VStack(spacing: 8) {
+                    Text("Welcome to Companion")
+                        .font(.title)
+                        .fontWeight(.medium)
+                    
+                    Text("Get started by adding your first MCP server")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            
+            // Buttons
+            VStack(spacing: 12) {
+                Button(action: onAddServer) {
+                    Label("Add Server...", systemImage: "plus.circle.fill")
+                        .font(.headline)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                
+                Button(action: onAddExampleServer) {
+                    Label("Add Example Server", systemImage: "star.circle")
+                        .font(.headline)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            
+            // Callout
+            HStack(spacing: 12) {
+                Image("mcp.fill")
+                    .foregroundStyle(.blue)
+                    .font(.system(size: 24))
+                
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("MCP servers provide tools, prompts, and resources to AI workflows")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                        .multilineTextAlignment(.leading)
+                    
+                    Link(destination: URL(string: "https://huggingface.co/learn/mcp-course/en/unit0/introduction")!) {
+                        HStack(spacing: 4) {
+                            Text("Learn more about MCP")
+                                .underline()
+                            Image(systemName: "arrow.up.right.square")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                    }
+                    .pointerStyle(.link)
+                }
+            }
+            .padding(12)
+            .background(.blue.opacity(0.1))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.blue, lineWidth: 1)
+            )
+            .clipped(antialiased: true)
+            .padding(.top, 8)
+        }
+        .frame(maxWidth: 400)
+        .padding()
+    }
+}
+
+#Preview {
+    WelcomeView(
+        onAddServer: {},
+        onAddExampleServer: {}
+    )
+        .frame(width: 600, height: 400)
+}


### PR DESCRIPTION
When opening the app for the first time, or when no servers are configured, the app now shows this:

<img width="461" alt="Screenshot 2025-07-02 at 01 45 16" src="https://github.com/user-attachments/assets/08361ace-f8a7-4e97-aa84-f171e7b7ef17" />
